### PR TITLE
Add support for unofficial instance URLs

### DIFF
--- a/source/api.c
+++ b/source/api.c
@@ -11,7 +11,7 @@ typedef struct user_gamedata_api user_gamedata_api;
 typedef struct user_api user_api;
 
 // Only call this after configuring the network. You bumbling idiot.
-user_api *get_user_api(const char *user_id) {
+user_api *get_user_api(const char *user_id, char *instance_host) {
 	char url[128];
 
 	// allocate memory for every struct
@@ -23,7 +23,7 @@ user_api *get_user_api(const char *user_id) {
 
 	// download API data
 	sprintf(url, "/api/user/%s", user_id);
-	winyl_response res_api = get_http("tag.rc24.xyz", 80, url);
+	winyl_response res_api = get_http(instance_host, 80, url);
 
 	json_t *api_root = json_loads(res_api.body, 0, &error);
 

--- a/source/api.h
+++ b/source/api.h
@@ -28,7 +28,7 @@ const char *voorhees_string_value(json_t *a, char *b);
 json_t *voorhees_object_get(json_t *a, char *b);
 json_t *voorhees_array_get(json_t *a, char *b);
 
-user_api *get_user_api(const char *user_id);
+user_api *get_user_api(const char *user_id, char *instance_host);
 
 void destroy_user_api(user_api *p);
 

--- a/source/config.c
+++ b/source/config.c
@@ -46,6 +46,10 @@ config *load_config() {
 	p->user_id = malloc(strlen(config_user_id)+1);
 	strcpy(p->user_id, config_user_id);
 
+	const char *config_instance_host = voorhees_string_value(config_root, "instance_host");
+	p->instance_host = malloc(strlen(config_instance_host)+1);
+	strcpy(p->instance_host, config_instance_host);
+
 	json_decref(config_root);
 	return p;
 }
@@ -54,5 +58,6 @@ void destroy_config(config *p) {
 	if (p == NULL) return;
 
 	free(p->user_id);
+	free(p->instance_host);
 	free(p);
 }

--- a/source/config.h
+++ b/source/config.h
@@ -3,6 +3,7 @@
 
 typedef struct config {
 	char *user_id;
+	char *instance_host;
 } config;
 
 config *load_config();

--- a/source/main.c
+++ b/source/main.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
 	loading++; draw_prog_prompt();
 
 	// get API data
-	api_res = get_user_api(cfg->user_id);
+	api_res = get_user_api(cfg->user_id, cfg->instance_host);
 	loading++; draw_prog_prompt();
 
 	// get tag image


### PR DESCRIPTION
The official LinkTag instance, tag.rc24.xyz, has been down for several months. This PR will allow users to select any instance, instead of being locked into the official instance. This also futureproofs the app, in case the domain or host changes or otherwise goes down.